### PR TITLE
fix direct download to docs presentation

### DIFF
--- a/lib/google_drive_direct_download/google/docs/direct_download.rb
+++ b/lib/google_drive_direct_download/google/docs/direct_download.rb
@@ -14,12 +14,9 @@ module Google
 
       def call
         return '' if invalid_file_url?
+        return "#{start_url}/d/#{file_id}/export/#{export_format}" if presentation_document?
 
-        if presentation_document?
-          "#{start_url}/d/#{file_id}/export/#{export_format}"
-        else
-          "#{start_url}/d/#{file_id}/export?format=#{export_format}"
-        end
+        "#{start_url}/d/#{file_id}/export?format=#{export_format}"
       end
 
       private
@@ -36,11 +33,11 @@ module Google
       end
 
       def presentation_document?
-        start_url == "#{BASE_URL}presentation"
+        file_type == 'presentation'
       end
 
       def file_type
-        @file_type ||= file_url.match(%r{[a-z]+/d}).to_s.gsub('/d', '')
+        @file_type ||= /(?<=\/)[a-z]+(?=\/d)/.match(file_url).to_s
       end
 
       def invalid_export_format?
@@ -56,7 +53,7 @@ module Google
       end
 
       def start_url
-        file_url.match(%r{[a-zA-Z0-9_\:/\.]+/d/}).to_s.gsub('/d/', '')
+        /.*(?=\/d)/.match(file_url)
       end
     end
   end

--- a/lib/google_drive_direct_download/google/docs/direct_download.rb
+++ b/lib/google_drive_direct_download/google/docs/direct_download.rb
@@ -15,7 +15,11 @@ module Google
       def call
         return '' if invalid_file_url?
 
-        "#{start_url}/d/#{file_id}/export?format=#{export_format}"
+        if file_type == 'presentation'
+          "#{start_url}/d/#{file_id}/export/#{export_format}"
+        else
+          "#{start_url}/d/#{file_id}/export?format=#{export_format}"
+        end
       end
 
       private
@@ -29,6 +33,10 @@ module Google
 
       def file_id
         @file_id ||= file_url.match(/\d[a-zA-Z0-9_-]+/).to_s
+      end
+
+      def file_type
+        @file_type ||= file_url.match(/[a-z]+\/d/).to_s.gsub('/d', '')
       end
 
       def invalid_export_format?

--- a/lib/google_drive_direct_download/google/docs/direct_download.rb
+++ b/lib/google_drive_direct_download/google/docs/direct_download.rb
@@ -15,7 +15,7 @@ module Google
       def call
         return '' if invalid_file_url?
 
-        if file_type == 'presentation'
+        if presentation_document?
           "#{start_url}/d/#{file_id}/export/#{export_format}"
         else
           "#{start_url}/d/#{file_id}/export?format=#{export_format}"
@@ -35,8 +35,12 @@ module Google
         @file_id ||= file_url.match(/\d[a-zA-Z0-9_-]+/).to_s
       end
 
+      def presentation_document?
+        start_url == "#{BASE_URL}presentation"
+      end
+
       def file_type
-        @file_type ||= file_url.match(/[a-z]+\/d/).to_s.gsub('/d', '')
+        @file_type ||= file_url.match(%r{[a-z]+/d}).to_s.gsub('/d', '')
       end
 
       def invalid_export_format?
@@ -52,7 +56,7 @@ module Google
       end
 
       def start_url
-        file_url.match(/[a-zA-Z0-9_\:\/\.]+\/d\//).to_s.gsub('/d/', '')
+        file_url.match(%r{[a-zA-Z0-9_\:/\.]+/d/}).to_s.gsub('/d/', '')
       end
     end
   end

--- a/spec/google/docs/direct_download_spec.rb
+++ b/spec/google/docs/direct_download_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe Google::Docs::DirectDownload do
         end
       end
 
+      context 'when presentation file' do
+        let(:file_url) { 'https://docs.google.com/presentation/d/1y0PEBZv47rfYkvLQugUv_RmInahlcMyo898fLabTxQ0/edit' }
+
+        it 'returns correct direct download url' do
+          is_expected.to eq('https://docs.google.com/presentation/d/1y0PEBZv47rfYkvLQugUv_RmInahlcMyo898fLabTxQ0/export/pdf')
+        end
+      end
+
       context 'when export format is not default' do
         let(:file_url) { 'https://docs.google.com/document/d/1y0PEBZv47rfYkvLQugUv_RmInahlcMyo898fLabTxQ0/edit?usp=sharing' }
         describe 'with valid export format' do


### PR DESCRIPTION
This PR has a goal to fix direct download link to Google Presentation Document

The direct download links for Google Slides is slightly different then Google Documents. Here replace /edit with /export/format where format can be pptx for downloading Google Slides as Microsoft Powerpoint files or PDF for exporting the presentation as a PDF slideshow.

shared link: 
https://docs.google.com/presentation/d/PRESENTATION_ID/edit
generate direct download link: 
https://docs.google.com/presentation/d/PRESENTATION_ID/export/pdf